### PR TITLE
Support for Oracle Database

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## 🚀 Features
 
-- **Multi-Database Support**: Works with MySQL, PostgreSQL, MariaDB, SQLite, MongoDB, MSSQL and Firebase.
+- **Multi-Database Support**: Works with MySQL, PostgreSQL, MariaDB, SQLite, MongoDB, MSSQL, OracleDB, and Firebase.
 - **Quick Data Inspection**: View all tables or a specific table with a simple command.
 - **User-Friendly CLI**: Easy-to-use command-line interface powered by Click.
 - **Secure Local Storage**: Securely store database connection details with encryption on your local machine.

--- a/peepdb/cli.py
+++ b/peepdb/cli.py
@@ -29,7 +29,7 @@ def cli():
     peepDB: A quick database table viewer.
 
     This tool allows you to quickly inspect database tables without writing SQL queries.
-    It supports MySQL, PostgreSQL, MariaDB, SQLite, MongoDB, Firebase, and MSSQL.
+    It supports MySQL, PostgreSQL, MariaDB, SQLite, MongoDB, Firebase, MSSQL, and OracleDB.
 
     Usage examples:
 
@@ -53,7 +53,7 @@ def cli():
 @cli.command()
 @click.argument('connection_name')
 @click.option('--db-type',
-              type=click.Choice(['mysql', 'postgres', 'mariadb', 'sqlite', 'mongodb', 'firebase', 'mssql']),
+              type=click.Choice(['mysql', 'postgres', 'mariadb', 'sqlite', 'mongodb', 'firebase', 'mssql', 'oracle']),
               required=True,
               help='Database type')
 @click.option('--host', required=True, help='Database host or file path for SQLite')

--- a/peepdb/core.py
+++ b/peepdb/core.py
@@ -11,7 +11,8 @@ from .db import (
     MongoDBDatabase,
     SQLiteDatabase,
     FirebaseDatabase,
-    MSSQLDatabase
+    MSSQLDatabase,
+    OracleDatabase
 )
 
 logger = logging.getLogger(__name__)
@@ -45,6 +46,9 @@ def connect_to_database(db_type: str, host: str, user: str, password: str, datab
         return FirebaseDatabase(host, **kwargs)
     elif db_type == 'mssql':
         return MSSQLDatabase(host, user, password, database, **kwargs)
+    elif db_type == 'oracle':
+        kwargs.pop('trusted', None)
+        return OracleDatabase(host, user, password, database, **kwargs)
     else:
         raise ValueError("Unsupported database type")
 

--- a/peepdb/db/__init__.py
+++ b/peepdb/db/__init__.py
@@ -6,6 +6,7 @@ from .mongodb import MongoDBDatabase
 from .sqlite import SQLiteDatabase
 from .firebase import FirebaseDatabase
 from .mssql import MSSQLDatabase
+from .oracle import OracleDatabase
 
 __all__ = [
     'BaseDatabase',
@@ -15,5 +16,6 @@ __all__ = [
     'MongoDBDatabase',
     'SQLiteDatabase',
     'FirebaseDatabase',
-    'MSSQLDatabase'
+    'MSSQLDatabase',
+    'OracleDatabase'
 ]

--- a/peepdb/db/oracle.py
+++ b/peepdb/db/oracle.py
@@ -1,0 +1,57 @@
+import oracledb
+from typing import List, Dict, Any
+from .base import BaseDatabase
+import logging
+
+
+class OracleDatabase(BaseDatabase):
+    def connect(self) -> None:
+        try:
+            self.connection = oracledb.connect(
+                host=self.host,
+                user=self.user,
+                password=self.password,
+                service_name=self.database,
+                port=self.port or 1521,
+                **self.extra_params,
+            )
+            self.cursor = self.connection.cursor()
+            self.logger.info(f"Connected to Oracle database: {self.database}")
+
+        except oracledb.Error as e:
+            self.logger.error(f"Error connecting to Oracle database: {e}")
+            raise
+
+    def disconnect(self) -> None:
+        if self.cursor:
+            self.cursor.close()
+        if self.connection:
+            self.connection.close()
+            self.logger.info(f"Disconnected from Oracle database: {self.database}")
+
+    def fetch_tables(self) -> List[str]:
+        self.cursor.execute("SELECT table_name FROM user_tables")
+        return [table[0] for table in self.cursor.fetchall()]
+
+    def fetch_data(
+        self, table: str, page: int = 1, page_size: int = 100
+    ) -> Dict[str, Any]:
+        offset = (page - 1) * page_size
+        self.cursor.execute(f"SELECT COUNT(*) as total FROM {table}")
+        total_rows = self.cursor.fetchone()[0]
+
+        self.cursor.execute(
+            f"SELECT * FROM {table} OFFSET {offset} ROWS FETCH NEXT {page_size} ROWS ONLY"
+        )
+        rows = self.cursor.fetchall()
+
+        column_names = [description[0] for description in self.cursor.description]
+
+        formatted_rows = [dict(zip(column_names, row)) for row in rows]
+
+        return {
+            "data": formatted_rows,
+            "page": page,
+            "total_pages": (total_rows + page_size - 1) // page_size,
+            "total_rows": total_rows,
+        }

--- a/peepdb/tests/test_peepdb.py
+++ b/peepdb/tests/test_peepdb.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock, patch
 from decimal import Decimal
 from peepdb.core import peep_db
 from peepdb.config import save_connection, get_connection, list_connections, remove_connection, remove_all_connections
-from peepdb.db import MySQLDatabase, PostgreSQLDatabase, MariaDBDatabase, MongoDBDatabase, FirebaseDatabase
+from peepdb.db import MySQLDatabase, PostgreSQLDatabase, MariaDBDatabase, MongoDBDatabase, FirebaseDatabase, OracleDatabase
 
 
 @patch('peepdb.core.FirebaseDatabase')
@@ -11,7 +11,8 @@ from peepdb.db import MySQLDatabase, PostgreSQLDatabase, MariaDBDatabase, MongoD
 @patch('peepdb.core.MySQLDatabase')
 @patch('peepdb.core.PostgreSQLDatabase')
 @patch('peepdb.core.MariaDBDatabase')
-def test_peep_db(mock_mariadb, mock_postgresql, mock_mysql, mock_mongodb, mock_firebase_db):
+@patch('peepdb.core.OracleDatabase')
+def test_peep_db(mock_mariadb, mock_postgresql, mock_mysql, mock_mongodb, mock_firebase_db, mock_oracle_db):
     # Create a mock database object
     mock_db = Mock()
     mock_db.fetch_tables.return_value = ['table1', 'table2']
@@ -31,6 +32,7 @@ def test_peep_db(mock_mariadb, mock_postgresql, mock_mysql, mock_mongodb, mock_f
     mock_mariadb.return_value = mock_db
     mock_mongodb.return_value = mock_db
     mock_firebase_db.return_value = mock_db
+    mock_oracle_db.return_value = mock_db
 
     # Expected result for non-scientific, JSON format
     expected_result = {
@@ -81,6 +83,10 @@ def test_peep_db(mock_mariadb, mock_postgresql, mock_mysql, mock_mongodb, mock_f
     result = peep_db('mongodb', 'host', 'user', 'password', 'database', format='json', scientific=False)
     assert result == expected_result
 
+    # Test OracleDB without scientific notation
+    result = peep_db('oracle', 'host', 'user', 'password', 'database', format='json', scientific=False)
+    assert result == expected_result
+
     # Test Firebase without scientific notation
     result = peep_db('firebase', 'path/to/serviceAccountKey.json', '', '', '', format='json', scientific=False)
     assert result == expected_result
@@ -103,6 +109,10 @@ def test_peep_db(mock_mariadb, mock_postgresql, mock_mysql, mock_mongodb, mock_f
 
     # Test MongoDB with scientific notation
     result = peep_db('mongodb', 'host', 'user', 'password', 'database', format='json', scientific=True)
+    assert result == expected_result
+
+    # Test OracleDB with scientific notation
+    result = peep_db('oracle', 'host', 'user', 'password', 'database', format='json', scientific=True)
     assert result == expected_result
 
     # Test fetching a specific table/collection for Firebase

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,6 +35,7 @@ mariadb==1.1.10
 more-itertools==10.5.0
 msgpack==1.1.0
 mysql-connector-python==9.0.0
+oracledb==2.5.1
 packaging==24.1
 -e git+https://github.com/evangelosmeklis/peepDB.git@4db25b049fce0058fa21e8f95b4b8840a9f3261e#egg=peepdb
 pluggy==1.5.0


### PR DESCRIPTION
Fixes #50.

- Added support for Oracle Database. 
- Tested on [Oracle Database XE Container](https://container-registry.oracle.com/ords/f?p=113:4:113966001642229:::4:P4_REPOSITORY,AI_REPOSITORY,AI_REPOSITORY_NAME,P4_REPOSITORY_NAME,P4_EULA_ID,P4_BUSINESS_AREA_ID:803,803,Oracle%20Database%20Express%20Edition,Oracle%20Database%20Express%20Edition,1,0&cs=31c2VvvD7912nLZQ8YddbUAqB4G2jSp19TJzs94P2i3kJHco7sBRJymOnXsdC0dF5dUgaiI-M_9ywJcyoafw26w).
- Applied PEP8 formatting using [black](https://github.com/psf/black)