### PR TITLE
add Dockerfile to containerize peepdb

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.12-slim-bookworm
+
+ARG version=0.1.4
+
+RUN apt update \
+        && apt install -y libmariadb3 libmariadb-dev gcc \
+        && pip install peepdb==$version \
+        && apt remove --purge -y gcc \
+        && apt autoremove --purge -y \
+        && apt-get clean
+
+ENTRYPOINT ["peepdb"]


### PR DESCRIPTION
Happy to make adjustments if requested. I only pinned the version of `peepdb` itself, as the installation instructions don't mention specific versions of other dependencies.

Also happy to add docs for building if desired. I built this with `docker build . -t peepdb:0.1.4`. To specify a different version of `peepdb` it can be done as `docker build --build-arg version=0.1.3 . -t peepdb:0.1.3`

I did some testing with `docker-compose` and afaict it works

```
$ docker exec -it peepdb-peepdb-1 bash
root@b70985d82d30:/# peepdb list
Saved connections:
- mysql1 (mysql)
- postgres1 (postgres)
root@b70985d82d30:/# peepdb view postgres1
INFO:PostgreSQLDatabase:Connected to PostgreSQL database: steve1
Fetching all tables
Tables fetched: ['accounts']
INFO:PostgreSQLDatabase:Disconnected from PostgreSQL database: steve1
Table: accounts
+------+------------+-------+
|   id | username   |   age |
+======+============+=======+
|    1 | steve      |    36 |
+------+------------+-------+
|    2 | bob        |    38 |
+------+------------+-------+
|    3 | jude       |     1 |
+------+------------+-------+
Page 1 of 1 (Total rows: 3)

```

The `~/.peepdb/` directory will have to be volume mounted into the container to not lose saved connections across containers, but that's more of a user preference, rather than part of building the docker image itself. I have a `docker-compose` file and setup that I was testing with if that would be helpful to include.

I tried to keep the image as small as I could, but some of the python packages, as well as the `libmariadb3 libmariadb-dev` requirements add a good amount of size (~300MB).

```
$ docker images
REPOSITORY      TAG                  IMAGE ID       CREATED          SIZE
peepdb          0.1.4                ac619680def2   9 minutes ago    422MB
python          3.12-slim-bookworm   6f3c6367c5a3   7 days ago       124MB
```

One of the `alpine` images could possibly be used if there's a strong desire to make the image smaller, but considering the installed packages themselves account for most of the space, I'm not sure how beneficial that would be. It also uses `apk` instead of `apt` and I didn't look into how the `mariadb` dependencies map to that package manager.

Thanks!

resolves https://github.com/evangelosmeklis/peepdb/issues/48