### PR TITLE
Update docs for db type options

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ layout: home
 
 ## 🚀 Features
 
-- **Multi-Database Support**: Works with MySQL, PostgreSQL, and MariaDB.
+- **Multi-Database Support**: Works with MySQL, PostgreSQL, MariaDB, SQLite, MongoDB, MSSQL, OracleDB, and Firebase.
 - **Quick Data Inspection**: View all tables or a specific table with a simple command.
 - **User-Friendly CLI**: Easy-to-use command-line interface powered by Click.
 - **Secure Local Storage**: Securely store database connection details with encryption on your local machine.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -12,7 +12,7 @@ peepDB provides a user-friendly command-line interface for interacting with your
 You can securely store your connection details for easier access:
 
 ```bash
-peepdb save <connection_name> --db-type [mysql/postgres/mariadb] --host <host> --user <user> --database <database>
+peepdb save <connection_name> --db-type [mysql/postgres/mariadb/sqlite/mongodb/firebase/mssql/oracle] --host <host> --user <user> --database <database>
 ```
 
 You'll be prompted securely for the password.


### PR DESCRIPTION
## Summary
- describe full list of supported database types on the docs homepage
- update the CLI example in the usage docs with all `--db-type` choices

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tabulate')*

------
https://chatgpt.com/codex/tasks/task_e_68400c9f96248326971649bb42f9da1a