### PR TITLE
Handle InvalidPassword in CLI

### DIFF
--- a/peepdb/cli.py
+++ b/peepdb/cli.py
@@ -137,7 +137,11 @@ def view(connection_name, table, format, page, page_size, scientific):
     Example:
     peepdb view mydb --table SomeTable
     """
-    connection = get_connection(connection_name)
+    try:
+        connection = get_connection(connection_name)
+    except InvalidPassword:
+        click.echo("Error: Unable to decrypt saved connection. Invalid password provided.")
+        raise SystemExit(1)
     if not connection:
         click.echo(f"Error: No saved connection found with name '{connection_name}'.")
         return

--- a/peepdb/tests/test_cli.py
+++ b/peepdb/tests/test_cli.py
@@ -1,6 +1,7 @@
 import pytest
 from click.testing import CliRunner
 from peepdb.cli import cli
+from peepdb.exceptions import InvalidPassword
 from unittest.mock import patch, MagicMock
 
 @pytest.fixture
@@ -97,6 +98,16 @@ def test_view_command_invalid_connection(mock_get_connection, runner):
 
     assert result.exit_code == 0
     assert "Error: No saved connection found with name 'invalid_conn'." in result.output
+
+
+@patch('peepdb.cli.get_connection')
+def test_view_command_invalid_password(mock_get_connection, runner):
+    mock_get_connection.side_effect = InvalidPassword()
+
+    result = runner.invoke(cli, ['view', 'bad_conn', '--table', 'users'])
+
+    assert result.exit_code != 0
+    assert "Error: Unable to decrypt saved connection. Invalid password provided." in result.output
 
 
 @patch('peepdb.cli.save_connection')


### PR DESCRIPTION
## Summary
- handle `InvalidPassword` in CLI `view` command
- test the CLI failure path for invalid password

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tabulate')*

------
https://chatgpt.com/codex/tasks/task_e_68400ca5bb908326b86b408699f3cdf7