### PR TITLE
Fix MongoDB extras and property typo

### DIFF
--- a/peepdb/db/mongodb.py
+++ b/peepdb/db/mongodb.py
@@ -17,21 +17,21 @@ class MongoDBDatabase(BaseDatabase):
 
             if self.extra_params:
                 params = '&'.join(
-                    [f"{k}={v}" for k, v in self.extra_params.items]
+                    [f"{k}={v}" for k, v in self.extra_params.items()]
                 )
 
                 mongo_uri = f"{mongo_uri}?{params}"
 
-            self.conection = pymongo.MongoClient(mongo_uri)
-            self.db = self.conection[self.database]
+            self.connection = pymongo.MongoClient(mongo_uri)
+            self.db = self.connection[self.database]
             self.logger.info(f"Connected to MongoDB database: {self.database}")
         except pymongo.errors.PyMongoError as e:
             self.logger.error(f"Error connecting to MongoDB database: {e}")
             raise
 
     def disconnect(self) -> None:
-        if self.conection:
-            self.conection.close()
+        if self.connection:
+            self.connection.close()
             self.logger.info(
                 f"Disconnected from MongoDB database: {self.database}"
             )

--- a/peepdb/tests/test_mongodb_uri.py
+++ b/peepdb/tests/test_mongodb_uri.py
@@ -1,0 +1,23 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from peepdb.db.mongodb import MongoDBDatabase
+
+
+def test_mongodb_connection_uri_generation():
+    db = MongoDBDatabase(
+        host='localhost',
+        user='user name',
+        password='p@ssword',
+        database='mydb',
+        port=1234,
+        replicaSet='rs0'
+    )
+    mock_client = MagicMock()
+    with patch('pymongo.MongoClient', return_value=mock_client) as mock_mc:
+        db.connect()
+        mock_mc.assert_called_once()
+        uri = mock_mc.call_args.args[0]
+
+    assert uri == 'mongodb://user+name:p%40ssword@localhost:1234/mydb?replicaSet=rs0'
+    assert db.connection is mock_client
+    assert db.db == mock_client.__getitem__.return_value


### PR DESCRIPTION
## Summary
- fix iteration over extra connection params when building MongoDB URI
- rename `conection` field to `connection`
- add regression test for MongoDB connection URI generation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tabulate')*

------
https://chatgpt.com/codex/tasks/task_e_68400ca2c2dc8326930f8512495bde75